### PR TITLE
feat: async backtest requests

### DIFF
--- a/src/execution/orchestrator.py
+++ b/src/execution/orchestrator.py
@@ -29,7 +29,7 @@ class Orchestrator:
         → RawExecutionResult (ready for metrics)
     """
 
-    _semaphore = asyncio.Semaphore(5)  # max 5 concurrent backtests
+    _semaphore = asyncio.Semaphore(13)  # 13 maximum backtests at a time (one for each member)
 
     def __init__(self):
         self.strategy_loader = StrategyLoader()
@@ -92,7 +92,7 @@ class Orchestrator:
                 )
                 
                 # Execute our payload
-                raw_result = self.executor.execute(payload)
+                raw_result = await asyncio.to_thread(self.executor.execute, payload)
                 
                 if not raw_result.errors.is_empty():
                     raise ExecutionException(raw_result.errors)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -346,7 +346,7 @@ class TestLoad: # TODO: Test a wider variety of strategies
     Simulate N concurrent users submitting backtest requests simultaneously.
     """
 
-    N = 5
+    N = 12
 
     @pytest.mark.asyncio
     async def test_concurrent_backtest_requests(self):


### PR DESCRIPTION
**ISSUE**
    - With this commit the backtester can now handle multiple concurrent requests, but now we have to alter our design to handle an arbitrary number of requests if we want this to be production ready.
    - If we have say, 7 requests, and we only allow up to 5 requests to go through at a time, the 2 left over requests will block for however long it takes for these spots to open up. Meaning, if one request takes 5 minutes to process, each of these 2 requests will have to wait 5 minutes each for their spots to fill up.
    - Obviously this won't scale, especially as multiple people run complex strategies

**Short-Term Fix (what this PR is for)**
    - Allow a preset amount of requests at a time (enough for each member of HQG) **(this commit)**
    - Just accept that multiple people will have to wait, and as of right now, time out their requests **(this commit)**
    - In order to fix the time-out issue, we could keep track of who's currently waiting for a response from our service and simply block them from being timed out until their request has actually been received. **(todo within this PR)**

**Long-term Proposal (low-priority, sometime in the future on a separate issue)**
    - I think something like an HPC cluster-inspired scheduler could be promising. This can just be called our **Scheduler**.
    - Each HTTP request should immediately respond with a job ID. This job ID should then be scheduled by our scheduler for the jobs to be ran and orchestrated by our **Orchestrator**.
    - This **Scheduler** would also make use of the Queue that Brendan is making.
    - Would probably take ~2 days to implement