### PR TITLE
fix: get trade timestamp from cache, not recalc every call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ local/
 src/strategy_temp/
 .pytest*
 logs/
+output.prof
+profile.py

--- a/src/services/backtester.py
+++ b/src/services/backtester.py
@@ -15,6 +15,7 @@ class Backtester:
     def __init__(self, data_provider: Optional[BaseDataProvider] = None):
         self.data_provider = data_provider or YFDataProvider()
         self.market_calendar = mcal.get_calendar("NYSE")
+        self._schedule_cache = None
     
     # TODO: add different types of fee structures (alpaca vs ibkr vs flat)
     async def run(self, strategy: Strategy, start_date: datetime, end_date: datetime, initial_capital: float = 10000.0) -> BacktestResult:
@@ -32,6 +33,7 @@ class Backtester:
         """
         symbols = strategy.universe()
         cadence = strategy.cadence()
+        self._schedule_cache = self.market_calendar.schedule(start_date=start_date - timedelta(days=10), end_date=end_date)
         
         # note: YF anchors weeks on whatever day you start on
         #  if you start on a weds, Open = last Thurs open and Close = this Weds close
@@ -177,17 +179,23 @@ class Backtester:
         timestamp_data = data.loc[final_timestamp]
         slice_obj = self._create_slice(timestamp_data)
         return self._get_prices(slice_obj, symbols)
-    
+        
     def _get_trade_timestamp(self, bar_timestamp: pd.Timestamp) -> datetime:
         """
-        Map a bar timestamp to the most recent trading day close at or before it (holiday edge case with weekly+ data).
-        If the bar label falls on a holiday/weekend, shift to the prior session close.
+        Map a bar timestamp to the most recent trading day close with cached schedule.
         """
         ts = pd.Timestamp(bar_timestamp).tz_localize(None)
-        schedule = self.market_calendar.schedule(
-            start_date=ts - timedelta(days=10),
-            end_date=ts
-        )
+        
+        # Use cached schedule
+        if self._schedule_cache is not None and not self._schedule_cache.empty:
+            schedule = self._schedule_cache[self._schedule_cache.index <= ts]
+        else:
+            # Fallback
+            schedule = self.market_calendar.schedule(
+                start_date=ts - timedelta(days=10),
+                end_date=ts
+            )
+        
         if schedule.empty:
             return ts.to_pydatetime()
 


### PR DESCRIPTION
Original problem: running a backtest with any amount of logic beyond "buy & hold" took > 60 seconds to run. For example, the below strategy originally took > 70 seconds locally.

```python

class SMA(Strategy):
    def __init__(self):
        self._initialized = False
        self._window = 21
        self._q = deque(maxlen=self._window)

    def universe(self) -> list[str]:
        return ["SPY", "BND"]

    def cadence(self) -> Cadence:
        return Cadence(bar_size=timedelta(days=1))

    def on_data(self, data: Slice, portfolio: PortfolioView) -> dict[str, float] | None:
        spy_close = data.close("SPY")
        
        if spy_close is None:
            return None
        
        self._q.append(spy_close)
        
        # wait until we have enough data
        if len(self._q) < self._window:
            if not self._initialized:
                self._initialized = True
                return {"BND": 1.0} # default
            return None
        
        mean_price = sum(self._q) / len(self._q)
        
        # if trailing mean < current price, buy 50% SPY + 50% BND, else 100% BND
        if mean_price < spy_close:
            # uptrend
            target_weights = {"SPY": 0.5, "BND": 0.5}
        else:
            # downtrend
            target_weights = {"BND": 1.0}
        
        self._initialized = True
        return target_weights


START = datetime(2015, 1, 1)
END = datetime(2026, 1, 31)

```

Proposed cache reduced run time to ~ 1 second; all statistics and dates seemed to remain the same.