### PR TITLE
fix: init sandbox image

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+
+COPY requirements-sandbox.txt .
+RUN pip install --no-cache-dir -r requirements-sandbox.txt
+
+COPY src/ src/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 services:
+  sandbox:
+    build:
+      context: .
+      dockerfile: Dockerfile.sandbox
+    image: hqg-backtester-sandbox
   backtester-api:
     build:
       context: .

--- a/requirements-sandbox.txt
+++ b/requirements-sandbox.txt
@@ -1,0 +1,6 @@
+pandas
+pydantic
+pydantic-settings
+pandas_market_calendars
+hqg_algorithms
+numpy

--- a/src/services/backtester.py
+++ b/src/services/backtester.py
@@ -6,14 +6,13 @@ from hqg_algorithms import Strategy, Slice, PortfolioView, Cadence
 from ..models.portfolio import Portfolio
 from ..models.response import Trade
 from ..services.data_provider.base_provider import BaseDataProvider
-from ..services.data_provider.yf_provider import YFDataProvider
 from ..execution.executor import RawExecutionResult
 
 
 class Backtester:
     
-    def __init__(self, data_provider: Optional[BaseDataProvider] = None):
-        self.data_provider = data_provider or YFDataProvider()
+    def __init__(self, data_provider: BaseDataProvider):
+        self.data_provider = data_provider
         self.market_calendar = mcal.get_calendar("NYSE")
         self._schedule_cache = None
     


### PR DESCRIPTION
* Added `hqg-backtester-sandbox` as a service in docker-compose so the image actually gets built (was missing, causing "image not found" errors)
* Created a lean `requirements-sandbox.txt`
* Removed strategy loader (with file-write logic that fails) from the entrypoint. current soln duplicates logic, but small fix
* Removed Backtester dependency on yfinance (not needed in sandbox as it accesses open internet). BT purely depends on whatever BaseDataProvider is injected (or, in our case, the data passed into the _loop lol)