### PR TITLE
Feat: config tab support

### DIFF
--- a/src/execution/container/entrypoint.py
+++ b/src/execution/container/entrypoint.py
@@ -90,6 +90,15 @@ def execute_backtest(payload: ExecutionPayload) -> Dict[str, Any]:
         # TODO: refactor w/ StrategyLoader (no write)
         # Load strategy class
         strategy_namespace = {}
+
+        # Inject config module if config_params provided
+        if payload.config_params:
+            import types
+            config_module = types.ModuleType('config')
+            for key, value in payload.config_params.items():
+                setattr(config_module, key, value)
+            sys.modules['config'] = config_module
+
         exec(payload.strategy_code, strategy_namespace)
 
         # Find Strategy subclass

--- a/src/execution/orchestrator.py
+++ b/src/execution/orchestrator.py
@@ -72,6 +72,8 @@ class Orchestrator:
                 logger.info(f"Fetched {len(data)} bars for {universe}")
 
                 # Convert DataFrame → JSON for container
+                
+                # TODO: Use Arrow IPC instead of JSON for faster serialization?
                 market_data_json = dataframe_to_json(data, universe)
 
                 # Build execution payload
@@ -82,7 +84,8 @@ class Orchestrator:
                     end_date=request.end_date,
                     initial_capital=request.initial_capital,
                     market_data=market_data_json,
-                    bar_size=cadence.bar_size
+                    bar_size=cadence.bar_size,
+                    config_params=request.config_params,
                 )
                 
                 # Execute our payload

--- a/src/execution/whitelists.py
+++ b/src/execution/whitelists.py
@@ -12,6 +12,7 @@ ALLOWED_MODULES: set[str] = {
     "statistics",
     # ML, data engineering
     "scikit-learn",
+    "xgboost"
     "sklearn",
     # Optimization
     "cvxpy",
@@ -21,6 +22,7 @@ ALLOWED_MODULES: set[str] = {
     # HQG framework
     "hqg_algorithms",
     "src",
+    "config",
     # Standard library (safe)
     "datetime",
     "typing",

--- a/src/models/execution.py
+++ b/src/models/execution.py
@@ -12,6 +12,7 @@ class ExecutionPayload(BaseModel):
     bar_size: BarSize = Field(default=None, description="Strategy BarSize")
     initial_capital: float = Field(default=100000.0, description="Starting cash of Python strategy", gt=0)
     market_data: Dict[str, Any] = Field(..., description="Pre-fetched OHLC data")
+    config_params: Optional[Dict[str, Any]] = Field(default=None, description="Config parameters to inject as 'config' module in sandbox")
 
 
 class RawExecutionResult(BaseModel):

--- a/src/models/request.py
+++ b/src/models/request.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field, field_validator, ValidationInfo
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Dict, Any
 
 
 class BacktestRequestError(BaseModel):
@@ -53,7 +53,18 @@ class BacktestRequest(BaseModel):
     initial_capital: float = Field(default=10000, gt=0)
     commission: Optional[float] = Field(default=0.0, ge=0, description="Commission per trade")
     slippage: Optional[float] = Field(default=0.0, ge=0, le=1.0, description="Slippage as percentage (0-1)")
+    config_params: Optional[Dict[str, Any]] = Field(default=None, description="Optional config parameters injected into the sandbox as 'config' module")
     errors: BacktestRequestError = Field(default_factory=BacktestRequestError, exclude=True)
+
+    @field_validator('config_params')
+    @classmethod
+    def validate_config_params(cls, v):
+        if v is None:
+            return v
+        import json
+        if len(json.dumps(v).encode('utf-8')) > 100_000:
+            raise ValueError("config_params too large (max 100KB)")
+        return v
 
     # TODO: make more robust
     @field_validator('strategy_code')


### PR DESCRIPTION
Pretty cool changes here. Our backtester now supports the handling of a config json file by simply accepting it through our response model then injecting it as a module into our namespace. From there, we simply add it to our allow list and call it from the main.py strategy code. Works the same as any other module you'd import. Also added xgboost to the whitelist in this PR.