### PR TITLE
fix: auth middleware caching

### DIFF
--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from functools import lru_cache
-from http.cookies import SimpleCookie
 import asyncio
 import json
 import threading
+import time
 import urllib.request
+from typing import Any
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from fastapi import Request, status
@@ -14,6 +14,13 @@ from fastapi.responses import JSONResponse
 import jwt
 
 from ..config.settings import settings
+
+KID_MISS_REFETCH_COOLDOWN_SECONDS = 5 * 60
+JWKS_FETCH_TIMEOUT_SECONDS = 5
+
+_jwks_lock = threading.Lock()
+_jwks_cache: dict[str, dict[str, Any]] = {}
+_last_kid_miss_refetch_at: dict[str, float] = {}
 
 
 class TimeoutMiddleware(BaseHTTPMiddleware):
@@ -125,12 +132,21 @@ class HqgAuthMiddleware(BaseHTTPMiddleware):
             )
 
         kid = header.get("kid")
+        if not kid:
+            return JSONResponse(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                content={"detail": "Unauthorized"},
+            )
 
-        # Fetch JWKS (cached)
-        jwks = self._get_jwks(self.jwks_url)
+        # Fetch JWKS from cache, then refresh once if the token kid is not found.
+        jwks = self._get_jwks(self.jwks_url, force_refresh=False)
         # Choose correct kid from JWKS.json
-        keys = jwks.get("keys") or []
+        keys = ((jwks or {}).get("keys") or [])
         jwk = next((key for key in keys if key.get("kid") == kid), None)
+        if not jwk:
+            refreshed_jwks = self._get_jwks(self.jwks_url, force_refresh=True)
+            refreshed_keys = ((refreshed_jwks or {}).get("keys") or [])
+            jwk = next((key for key in refreshed_keys if key.get("kid") == kid), None)
 
         if not jwk:
             return JSONResponse(
@@ -188,7 +204,27 @@ class HqgAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
     @staticmethod
-    @lru_cache(maxsize=4)
-    def _get_jwks(jwks_url: str):
-        with urllib.request.urlopen(jwks_url, timeout=5) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+    def _get_jwks(jwks_url: str, force_refresh: bool = True) -> dict[str, Any] | None:
+        now = time.monotonic()
+
+        with _jwks_lock:
+            cached = _jwks_cache.get(jwks_url)
+            if not force_refresh and cached is not None:
+                return cached
+
+            if force_refresh:
+                last_refresh = _last_kid_miss_refetch_at.get(jwks_url, 0.0)
+                if now - last_refresh < KID_MISS_REFETCH_COOLDOWN_SECONDS:
+                    return cached
+                _last_kid_miss_refetch_at[jwks_url] = now
+
+        try:
+            with urllib.request.urlopen(jwks_url, timeout=JWKS_FETCH_TIMEOUT_SECONDS) as resp:
+                fresh = json.loads(resp.read().decode("utf-8"))
+        except Exception:
+            with _jwks_lock:
+                return _jwks_cache.get(jwks_url)
+
+        with _jwks_lock:
+            _jwks_cache[jwks_url] = fresh
+        return fresh

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,121 @@
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api import middleware
+from src.api.middleware import HqgAuthMiddleware
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+@pytest.fixture(autouse=True)
+def clear_jwks_cache():
+    middleware._jwks_cache.clear()
+    middleware._last_kid_miss_refetch_at.clear()
+    yield
+    middleware._jwks_cache.clear()
+    middleware._last_kid_miss_refetch_at.clear()
+
+
+@pytest.mark.unit
+def test_get_jwks_reuses_cached_response(monkeypatch):
+    calls = []
+    jwks = {"keys": [{"kid": "cached"}]}
+
+    def fake_urlopen(url, timeout):
+        calls.append((url, timeout))
+        return _FakeResponse(jwks)
+
+    monkeypatch.setattr(middleware.urllib.request, "urlopen", fake_urlopen)
+
+    first = HqgAuthMiddleware._get_jwks("https://example.com/jwks.json", force_refresh=False)
+    second = HqgAuthMiddleware._get_jwks("https://example.com/jwks.json", force_refresh=False)
+
+    assert first == jwks
+    assert second == jwks
+    assert calls == [("https://example.com/jwks.json", middleware.JWKS_FETCH_TIMEOUT_SECONDS)]
+
+
+@pytest.mark.unit
+def test_get_jwks_force_refresh_is_throttled(monkeypatch):
+    cached = {"keys": [{"kid": "old"}]}
+    middleware._jwks_cache["https://example.com/jwks.json"] = cached
+    middleware._last_kid_miss_refetch_at["https://example.com/jwks.json"] = 1000.0
+
+    def fake_urlopen(url, timeout):
+        raise AssertionError("urlopen should not run during cooldown")
+
+    monkeypatch.setattr(middleware.time, "monotonic", lambda: 1100.0)
+    monkeypatch.setattr(middleware.urllib.request, "urlopen", fake_urlopen)
+
+    jwks = HqgAuthMiddleware._get_jwks("https://example.com/jwks.json", force_refresh=True)
+
+    assert jwks == cached
+
+
+@pytest.mark.unit
+def test_get_jwks_returns_cached_response_when_refresh_fails(monkeypatch):
+    cached = {"keys": [{"kid": "old"}]}
+    middleware._jwks_cache["https://example.com/jwks.json"] = cached
+
+    def fake_urlopen(url, timeout):
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr(middleware.time, "monotonic", lambda: 1000.0)
+    monkeypatch.setattr(middleware.urllib.request, "urlopen", fake_urlopen)
+
+    jwks = HqgAuthMiddleware._get_jwks("https://example.com/jwks.json", force_refresh=True)
+
+    assert jwks == cached
+
+
+@pytest.mark.unit
+def test_auth_refreshes_jwks_on_kid_miss(monkeypatch):
+    calls = []
+
+    def fake_get_jwks(jwks_url, force_refresh=True):
+        calls.append(force_refresh)
+        if force_refresh:
+            return {"keys": [{"kid": "rotated"}]}
+        return {"keys": [{"kid": "old"}]}
+
+    monkeypatch.setattr(HqgAuthMiddleware, "_get_jwks", staticmethod(fake_get_jwks))
+    monkeypatch.setattr(middleware.jwt, "get_unverified_header", lambda token: {"kid": "rotated"})
+    monkeypatch.setattr(
+        middleware.jwt.algorithms.RSAAlgorithm,
+        "from_jwk",
+        lambda jwk: "public-key",
+    )
+    monkeypatch.setattr(
+        middleware.jwt,
+        "decode",
+        lambda token, key, algorithms, options: {"sub": "netid", "roles": ["PUBLIC"]},
+    )
+
+    app = FastAPI()
+    app.add_middleware(HqgAuthMiddleware, jwks_url="https://example.com/jwks.json")
+
+    @app.get("/api/protected")
+    async def protected():
+        return {"ok": True}
+
+    client = TestClient(app)
+    response = client.get("/api/protected", cookies={"hqg_auth_token": "token"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert calls == [False, True]


### PR DESCRIPTION
Fixes the issue where we have to keep redeploying the backtester when hqg-dash rotates kid (key id) values on auth tokens.

Changed the auth middleware to reflect what hqg-platform does for its caching strategy:
- If kid exists in cache, use it to verify jwt
- If kid does not exist in cache, refresh cache.

Cache refreshes add 50-100ms of response time to each request, so we want to limit them. Good requests will 99.9% of the time not need a cache refresh. If a bad actor kept spamming tokens with invalid kid's, then it doesn't matter that their request is slower because it will just get rejected (it will also just not make it to hqg-backtester anyway, would get denied in platform)

Also this branch added a test to make sure the middleware doesn't regress. When are we adding CI workflows for the tests we currently have?