### PR TITLE
fix: add leeway to jwt decoding

### DIFF
--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -172,6 +172,7 @@ class HqgAuthMiddleware(BaseHTTPMiddleware):
                 token,
                 public_key,
                 algorithms=["RS256"],
+                leeway=90,
                 options={"require": ["exp", "sub"]},
             )
         except jwt.PyJWTError:


### PR DESCRIPTION
Adds 90 second leeway to JWT decoding to fix clock-drift on SoB VM.